### PR TITLE
Parallel superpose (hyperpose) to allow using multiple CPU cores

### DIFF
--- a/mettamorph.metta
+++ b/mettamorph.metta
@@ -6,6 +6,10 @@
 
 (: sequential (-> Expression %Undefined%))
 (= (sequential $1) (superpose $1))
+
+(: hyperpose (-> Expression %Undefined%))
+(= (hyperpose $1) (superpose $1))
+
 (: do (-> Expression %Undefined%))
 (= (do $1) (case $1 ()))
 

--- a/mettamorph.scm
+++ b/mettamorph.scm
@@ -51,8 +51,7 @@
                                          (amb1 res1)
                                          (amb1 (list (amb1 res1) (amb1 res2)))))))))))
     ((_ arg1 arg2 argi ...)
-     (let ((chain (amb-parallel (amb-collect arg1) (amb-collect (amb-parallel arg2 argi ...)))))
-          (amb1 chain)))))
+     (amb1 (amb-parallel (amb-collect arg1) (amb-collect (amb-parallel arg2 argi ...)))))))
 
 ;hyperpose-helper enforces nested superpose compatibility
 ;by flatting out the nested hyperpose calls before passing it to amb-parallel

--- a/mettamorph.scm
+++ b/mettamorph.scm
@@ -43,7 +43,7 @@
                             (exit 0)) ;child is done
                        (let* ((res1 (amb-collect arg1)) ;we cannot backtrack here either, the child counts on the parent, so we collect all of this level's results
                               (res2 (read (open-input-file* pipefd0)))) ;after we collected our results we can collect the result of the child
-                             (if (and (null? res1) (null? res2))
+                             (if (and (null? res1) (null? res2)) ;but from here we can backtrack safely yet again
                                  ((amb-failure-continuation))
                                  (if (null? res1)
                                      (amb1 res2)

--- a/mettamorph.scm
+++ b/mettamorph.scm
@@ -4,7 +4,7 @@
 (import matchable)         ;let/case constructs as match-lambda with deconstruction
 (import (chicken flonum))  ;floating point options
 (import (chicken type))    ;type system
-(import (chicken process) (chicken string) (chicken file posix) srfi-13) ;fork, pipe, file API etc. for hyperpose
+(import (chicken process) (chicken file posix)) ;fork, pipe, file API for hyperpose
 
 ;; COLLAPSE AND SUPERPOSE
 ;""""""""""""""""""""""""
@@ -345,3 +345,8 @@
   (syntax-rules ()
     ((_ x y)
      (begin (display (auto-list1 x)) (newline) (auto-list1 y)))))
+
+;; MATH
+;"""""""
+
+(define (% a b) (modulo a b))

--- a/tests/hyperpose.metta
+++ b/tests/hyperpose.metta
@@ -11,3 +11,5 @@
 !(hyperpose (1 (If (== 1 2) 1) (If (== 1 2) 1)))
 
 !(hyperpose (1 2 3 4))
+
+!(hyperpose ((1 2) (3 4)))

--- a/tests/hyperpose.metta
+++ b/tests/hyperpose.metta
@@ -1,0 +1,13 @@
+!(hyperpose (1 2))
+
+!(hyperpose (1 (If (== 1 2) 1)))
+!(hyperpose ((If (== 1 2) 1) 1))
+
+!(hyperpose (1 2 3))
+
+!(hyperpose ((If (== 1 2) 1) 2 3))
+!(hyperpose (1 (If (== 1 2) 1) 3))
+!(hyperpose (1 2 (If (== 1 2) 1)))
+!(hyperpose (1 (If (== 1 2) 1) (If (== 1 2) 1)))
+
+!(hyperpose (1 2 3 4))

--- a/tests/hyperpose_primes.metta.inactive
+++ b/tests/hyperpose_primes.metta.inactive
@@ -1,0 +1,13 @@
+;test deactivated with file name extension as it is computationally expensive, only feasible with the compiler
+(= (find-divisor $n $test-divisor)
+   (If (> (* $test-divisor $test-divisor) $n)
+       $n
+       (If (== 0 (% $n $test-divisor))
+           $test-divisor
+           (find-divisor $n (+ $test-divisor 1)))))
+
+(= (prime? $n)
+   (== $n (find-divisor $n 2)))
+
+!(hyperpose ((prime? 53537257) (prime? 53781811)
+             (prime? 54218443) (prime? 54734431)))


### PR DESCRIPTION
Gists from which it grew:
Parallel list:
https://gist.github.com/patham9/1258c899c1848a2219671c47d4b356b6
Parallel amb:
https://gist.github.com/patham9/077a1b8772396251e46b63bd2a60ebce
Initial attempts: (thanks a lot to siiky from the Chicken Scheme community for the valuable input!!)
https://gist.github.com/patham9/d1e09c2f346a9e17b5c8e946bb5a1421

The time spent for parallel-amb is the maximum time spent on any of the branches (plus the forking and synchronization overhead for collecting results).

Example:
```
(= (find-divisor $n $test-divisor)
   (If (> (* $test-divisor $test-divisor) $n)
       $n
       (If (== 0 (% $n $test-divisor))
           $test-divisor
           (find-divisor $n (+ $test-divisor 1)))))

(= (prime? $n)
   (== $n (find-divisor $n 2)))

!(hyperpose ((prime? 53537257) (prime? 53781811)
             (prime? 54218443) (prime? 54734431)))
```

On my outdated Dual Core CPU `superpose` takes almost twice as long as `hyperpose` here, more speedup can be expected on modern processors.